### PR TITLE
Add dockerfile for ocp and owners for prow conf

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,0 +1,11 @@
+FROM rhel7:latest
+
+RUN yum install -y python-requests && \
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current && \
+    yum update -y && \
+    yum install -y openstack-ironic-python-agent lshw smartmontools && \
+    yum clean all
+
+# NOTE(TheJulia/juliakreger): this command defaults to using multicast
+# dns lookups.
+ENTRYPOINT ["/usr/bin/ironic-collect-introspection-data", "--introspection_daemon"]

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+  - bfournie
+  - derekhiggins
+  - dhellmann
+  - dtantsur
+  - elfosardo
+  - hardys
+  - juliakreger
+  - russellb
+reviewers:
+  - bfournie
+  - derekhiggins
+  - dhellmann
+  - dtantsur
+  - elfosardo
+  - hardys
+  - juliakreger
+  - russellb


### PR DESCRIPTION
This patch adds Dockerfile.ocp to distinguish from the upstream
Dockerfile that has content that we can't use downstream.
Also adds OWNERS for prow and ci configuration.