### PR TITLE
Bug 1784319: Make image identify itself as component of the release

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -7,3 +7,5 @@ RUN yum update -y && \
 COPY ./runironic-agent.sh /bin/runironic-agent
 
 ENTRYPOINT ["/bin/runironic-agent"]
+
+LABEL io.openshift.release.operator true


### PR DESCRIPTION
The image is currently not published as it's ignored by the
release mechanism.
Adding the LABEL io.openshift.release.operator true should force
the release mechanism to recognize the image as part of the
release.

Cherry-picked from #495 