### PR TITLE
Updating ironic-hardware-inventory-recorder-image builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 
 RUN dnf update -y && \
     dnf install -y openstack-ironic-python-agent lshw smartmontools iproute python3-hardware && \


### PR DESCRIPTION
Updating ironic-hardware-inventory-recorder-image builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ironic-hardware-inventory-recorder-image.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
